### PR TITLE
Added Bitout_integral_value

### DIFF
--- a/iterator_bitset_plus/biterator.hpp
+++ b/iterator_bitset_plus/biterator.hpp
@@ -9,6 +9,7 @@
 namespace biterator {
     namespace detail
     {
+            // Used to determine if the bits being read by the Bitsource_forward_iter are ascending or descending.
         enum struct Direction { Up, Down, Neither};
         consteval auto direction(auto start_bit = 0, auto last_bit = 7)
             requires std::is_same_v<decltype(start_bit),decltype(last_bit)> and
@@ -34,162 +35,125 @@ namespace biterator {
     template <typename Container> concept Integral_container = std::integral<typename Container::value_type>;
     
     /*
-        Bitset_output_iter is an output iterator that writes a bit at time into an std::bitset.
-        Note that it starts with the most significant bit and writes to the least significant bit.
-    */
-    template <std::size_t bitset_size>  // value
-    struct Bitset_output_iter
-    {
-        using iterator_category = std::output_iterator_tag;
-        using difference_type   = std::ptrdiff_t;
-        using value_type        = bool;
-        Bitset_output_iter() = default;
-        Bitset_output_iter(Bitset_output_iter const& orginal) = default;
-        Bitset_output_iter(std::bitset<bitset_size> & bs, std::size_t initial_offset = 0):
-            bs_{ &bs },
-            offset_{bitset_size - initial_offset - 1}
-        {}
-        auto operator*() -> Bitset_output_iter & { return *this; }
-        auto operator++()    /* postfix */ -> Bitset_output_iter & { --offset_; return *this; }
-        auto operator++(int) /* postfix */ -> Bitset_output_iter   { --offset_; return *this; }
-        auto operator==(const Bitset_output_iter& rhs) const { return bs_ == rhs.bs_ and offset_ == rhs.offset_; }
-        auto operator!=(const Bitset_output_iter& rhs) const { return not (*this == rhs); }
-        auto operator=(bool val) -> Bitset_output_iter &
-        {
-            (*bs_)[offset_] = val;
-            return *this;
-        }
-    private:
-        std::bitset<bitset_size> *bs_{nullptr};
-        std::size_t              offset_{0};
-    };
-    
-    /*
-        Bitset_const_forward_iter is an read-only forward iterator that reads a bit at time.
+        bitset_iter is an random-access iterator that reads/writes a bit at time.
         Note that it starts with the most significant bit and reads to the least significant bit.
     */
-    template <std::size_t bitset_size>  // value
-    struct Bitset_const_forward_iter
+    template <std::size_t bitset_size>
+    struct bitset_iter
     {
-        using iterator_category = std::forward_iterator_tag;
-        using difference_type   = std::ptrdiff_t;
-        using value_type        = bool;
-        Bitset_const_forward_iter() = default;
-        Bitset_const_forward_iter(Bitset_const_forward_iter const& orginal) = default;
-        Bitset_const_forward_iter(std::bitset<bitset_size> & bs, std::size_t initial_offset = 0):
-            bs_{ &bs },
-            offset_{ bitset_size - initial_offset - 1}
-        {}
-        auto operator*() -> Bitset_const_forward_iter & { return (*bs_)[offset_]; }
-        auto operator++()    /* prefix */  -> Bitset_const_forward_iter & { --offset_; return *this; }
-        auto operator++(int) /* postfix */ -> Bitset_const_forward_iter   { --offset_; return *this; }
-        auto operator==(const Bitset_const_forward_iter& rhs) const { return bs_ == rhs.bs_ and offset_ == rhs.offset_; }
-        auto operator!=(const Bitset_const_forward_iter& rhs) const { return not (*this == rhs); }
-        auto operator=(bool val) -> Bitset_const_forward_iter &
+        /*
+            The BitRefProxy type is returned when we need to return a reference to a bool inside the bitset.
+            Since the bitset is (likely) implemented with bits of integers rather than bools, we can't actually
+            return a reference to a bool. Instead we return this class. We can read and write the correct bool
+            value this this proxy to the Boolean value in the bitset. 
+        */
+        struct BitRefProxy
         {
-            (*bs_)[offset_] = val;
-            return *this;
-        }
-    private:
-        std::bitset<bitset_size> *bs_{nullptr};
-        std::size_t              offset_{0};
-    };
-    
-    /*
-        Bitset_iter is an random-access iterator that reads/writes a bit at time.
-        Note that it starts with the most significant bit and reads to the least significant bit.
-    */
-    template <std::size_t bitset_size>  // value
-    struct Bitset_iter
-    {
-        using iterator_category = std::random_access_iterator_tag;
-        using difference_type   = std::ptrdiff_t;
-        using value_type        = bool;
-        struct BitRef
-        {
-            BitRef() {}
-            BitRef(BitRef const&) = default;
-            BitRef(std::bitset<bitset_size> & bs, std::size_t initial_offset = 0):
+            BitRefProxy() {}
+            BitRefProxy(BitRefProxy const&) = default;
+            BitRefProxy(std::bitset<bitset_size> & bs, std::size_t initial_offset = 0):
                 bs_{ &bs },
                 offset_{ bitset_size - initial_offset - 1}
             {}
             operator bool() const {return (*bs_)[offset_];}
-            BitRef& operator=(bool v) {(*bs_)[offset_] = v; return *this;}
+            BitRefProxy& operator=(bool v) {(*bs_)[offset_] = v; return *this;}
             private:
                 std::bitset<bitset_size> *bs_{nullptr};
                 std::size_t              offset_{0};
         };
-        using reference         = BitRef;
-        using pointer           = bool const *;
-        Bitset_iter() = default;
-        Bitset_iter(Bitset_iter const& orginal) = default;
-        Bitset_iter(std::bitset<bitset_size> & bs, std::size_t initial_offset = 0):
+
+        // Boiler plate iterator nested types.
+        using iterator_category = std::random_access_iterator_tag;
+        using difference_type   = std::ptrdiff_t;
+        using value_type        = bool;
+        using reference         = BitRefProxy;
+        // using pointer           = bool *; // Not needed and problematic to implement due to the proxy issue.
+
+        bitset_iter() = default;
+        bitset_iter(bitset_iter const& orginal) = default;
+        bitset_iter(std::bitset<bitset_size> & bs, std::size_t initial_offset = 0):
             bs_{ &bs },
             offset_{ bitset_size - initial_offset - 1}
         {}
-        auto operator*() -> BitRef { return BitRef(*bs_, offset_);}
-        auto operator++()    /* prefix */  -> Bitset_iter & { --offset_; return *this; }
-        auto operator++(int) /* postfix */ -> Bitset_iter   { --offset_; return *this; }
-        auto operator==(const Bitset_iter& rhs) const { return bs_ == rhs.bs_ and offset_ == rhs.offset_; }
-        auto operator!=(const Bitset_iter& rhs) const { return not (*this == rhs); }
-        auto operator=(bool val) -> Bitset_iter &
+        auto operator*() -> BitRefProxy { return BitRefProxy(*bs_, offset_);}
+
+        // Should probably add some asserts to inc and dec operators.
+        auto operator++()    /* prefix */  -> bitset_iter & { --offset_; return *this; }
+        auto operator++(int) /* postfix */ -> bitset_iter   { auto result{*this}; ++this; return result; }
+        auto operator--()    /* prefix */  -> bitset_iter & { ++offset_; return *this; }
+        auto operator--(int) /* postfix */ -> bitset_iter   { auto result{*this}; --this; return result; }
+
+        auto operator==(const bitset_iter& rhs) const
+        {
+            // "end" iterators are all equal
+            if ((not bs_ and not rhs.bs_)
+                or (not bs_ and rhs.offset_ + 1 == bitset_size)
+                or (offset_ + 1 == bitset_size and not rhs.bs_))
+            {
+                return true;
+            }
+            return bs_ == rhs.bs_ and offset_ == rhs.offset_;
+        }
+        auto operator!=(const bitset_iter& rhs) const { return not (*this == rhs); }
+        auto operator=(bool val) -> bitset_iter &
         {
             (*bs_)[offset_] = val;
             return *this;
         }
 
+        // Random Access
         // Comparison functions iterators must reference the same container.
-        friend auto operator<(Bitset_iter const& rhs,  Bitset_iter const& lhs)
+        friend auto operator<(bitset_iter const& rhs,  bitset_iter const& lhs)
         {
             assert(((not rhs.bs_) or (not lhs.bs_)) && "Comparing iterator not referencing a container.");
             assert(rhs.bs_ == lhs.bs_ && "Comparing iterators from different containers.");
             return rhs.offset > lhs.offset; // Offset progress downward, so > offset reflects a < interator.
         };
-        friend auto operator>(Bitset_iter const& rhs,  Bitset_iter const& lhs)
+        friend auto operator>(bitset_iter const& rhs,  bitset_iter const& lhs)
         {
             assert(((not rhs.bs_) or (not lhs.bs_)) && "Comparing iterator not referencing a container.");
             assert(rhs.bs_ == lhs.bs_ && "Comparing iterators from different containers.");
             return rhs.offset < lhs.offset; // Offset progress downward, so < offset reflects a > interator.
         };
-        friend auto operator<=(Bitset_iter const& rhs,  Bitset_iter const& lhs)
+        friend auto operator<=(bitset_iter const& rhs,  bitset_iter const& lhs)
         {
             assert(((not rhs.bs_) or (not lhs.bs_)) && "Comparing iterator not referencing a container.");
             assert(rhs.bs_ == lhs.bs_ && "Comparing iterators from different containers.");
             return rhs.offset >= lhs.offset; // Offset progress downward, so >= offset reflects a <= interator.
         };
-        friend auto operator>=(Bitset_iter const& rhs,  Bitset_iter const& lhs)
+        friend auto operator>=(bitset_iter const& rhs,  bitset_iter const& lhs)
         {
             assert(((not rhs.bs_) or (not lhs.bs_)) && "Comparing iterator not referencing a container.");
             assert(rhs.bs_ == lhs.bs_ && "Comparing iterators from different containers.");
             return rhs.offset <= lhs.offset; // Offset progress downward, so <= offset reflects a >= interator.
         };
     
-        Bitset_iter& operator+=(int delta)
+        bitset_iter& operator+=(int delta)
         {
             assert(delta <= offset_ && "Incrementing iterator past end of bitset.");
             offset_ -= delta; return this;
         }
-        friend Bitset_iter operator+(Bitset_iter const& lhs, int delta)
+        friend bitset_iter operator+(bitset_iter const& lhs, int delta)
         {
-            assert(delta <= lhs.offset_ && "Incrementing iterator past end of bitset.");
-            return Bitset_iter(lhs.bs_, lhs.offset_ - delta);
+            assert(delta <= (lhs.offset_ + 1) && "Incrementing iterator past end of bitset.");
+            return bitset_iter(*lhs.bs_, bitset_size - lhs.offset_ - 1 + delta);
         }
-        friend Bitset_iter operator+(int delta, Bitset_iter const& rhs)
+        friend bitset_iter operator+(int delta, bitset_iter const& rhs)
         {
             assert(delta <= rhs.offset_ && "Incrementing iterator past end of bitset.");
-            return Bitset_iter(rhs.bs_, rhs.offset_ - delta);
+            return bitset_iter(*rhs.bs_, rhs.offset_ - delta);
         }
-        Bitset_iter& operator-=(int delta)
+        bitset_iter& operator-=(int delta)
         {
             assert(bitset_size - offset_ <= delta && "Decrementing iterator before beginning of bitset.");
             offset_ += delta; return this;
         }  
-        friend Bitset_iter operator-(Bitset_iter const& lhs, int delta)
+        friend bitset_iter operator-(bitset_iter const& lhs, int delta)
         {
             assert(bitset_size - lhs.offset_ <= delta && "Decrementing iterator before beginning of bitset.");
-            return Bitset_iter(lhs.bs_, lhs.offset_ + delta);
+            return bitset_iter(*lhs.bs_, lhs.offset_ + delta);
         }  
-        friend difference_type operator-(Bitset_iter const& lhs, Bitset_iter const& rhs)
+        friend difference_type operator-(bitset_iter const& lhs, bitset_iter const& rhs)
         {
             assert(rhs.bs_ == lhs.bs_ && "Subtracting iterators from different containers.");
             return difference_type(rhs.offset) - difference_type(lhs.offset_);
@@ -204,51 +168,132 @@ namespace biterator {
     };
     
     /*
+        Bitout_integral_value is an output iterator that writes bits into an integral values.
+        The caller specifies a range of bits with the integral value.
+    */
+    
+    template <auto start_bit, auto last_bit, std::integral integral_t>
+        requires std::is_integral_v<decltype(start_bit)> and std::is_integral_v<decltype(last_bit)>
+    struct Bitout_integral_value
+    {
+        // Boiler plate iterator nested types.
+        using iterator_category = std::output_iterator_tag;
+        using value_type        = bool;
+        using difference_type   = std::ptrdiff_t;
+        using reference         = bool const &;
+        //using pointer           = bool const *;   // probably not needed
+
+        Bitout_integral_value(integral_t& sink): sink_{sink} {}
+
+        auto operator*() -> Bitout_integral_value & { return *this; }
+        auto operator++() /* prefix */
+        {
+            increment_mask(current_mask_, direction_);
+            return *this;
+        }
+        auto operator++(int) /* postfix */
+        {
+            auto result{*this};
+            ++this;
+            return result;
+        }
+        auto operator=(bool val) -> Bitout_integral_value &
+        {
+            sink_ |= (val * current_mask_);
+            return *this;
+        }
+        auto operator==(Bitout_integral_value const &other) const
+        {
+            return &sink_ == other.sink_ and current_mask_ == other.current_mask_;
+        }
+        auto operator!=(Bitout_integral_value const &other) const { return !(*this == other); }
+
+    private:
+        static constexpr uintmax_t         start_mask_  { detail::make_mask(start_bit) };
+        static constexpr uintmax_t         last_mask_   { detail::make_mask(last_bit) };
+        static constexpr detail::Direction direction_   { detail::direction(start_bit, last_bit) };
+        integral_t                         &sink_;
+        uintmax_t                          current_mask_{ start_mask_ };
+    };
+    
+    template <std::integral integral_t, auto start_bit = 6, auto last_bit = 0>
+    auto begin(integral_t &value) { return Bitout_integral_value<start_bit, last_bit, integral_t>{ value }; }
+
+    
+    /*
         Bitsource_forward_iter is an forward iterator that reads bits from a source container of integral values (an Integral_container).
         The caller specifies a range of bits of each source value.
     */
     
     template <auto start_bit = 6, auto last_bit = 0, Integral_container Container = std::string>
         requires std::is_integral_v<decltype(start_bit)> and std::is_integral_v<decltype(last_bit)>
-    struct Bitsource_forward_iter {  // forward iterator for reading an Integral_container.
+    struct Bitsource_forward_iter
+    {
+        // Boiler plate iterator nested types.
         using iterator_category = std::forward_iterator_tag;
         using value_type        = bool;
         using difference_type   = std::ptrdiff_t;
         using reference         = bool const &;
-        using pointer           = bool const *;
-        Bitsource_forward_iter(                                                   ): container_{ nullptr }                                      {}
-        Bitsource_forward_iter( Container& container                              ): container_{ &container }, cont_iter_{ begin(*container_) } {}
-        Bitsource_forward_iter( Container& container, Container::const_iterator it): container_{ &container }, cont_iter_{ it}                  {}
-        reference operator*() const {
+        //using pointer           = bool const *;   // probably not needed
+
+        Bitsource_forward_iter(): container_{ nullptr }                                      {}
+        Bitsource_forward_iter( Container& container ):
+            container_{ &container },
+            cont_iter_{ begin(*container_) }
+        {}
+        Bitsource_forward_iter( Container& container, Container::const_iterator it):
+            container_{ &container },
+            cont_iter_{ it}
+        {}
+
+        //pointer operator->() { return &operator*(); }   // probably not needed
+        reference operator*() const
+        {
             assert(container_ and "Dereferencing iterator with no container.");
             assert((end(*container_) != cont_iter_) and "Dereferencing past end of container");
             current_value_ = *cont_iter_ & current_mask_;
             return current_value_;
         }
-        pointer operator->() const { return &operator*(); }
-        Bitsource_forward_iter & operator++() {
+        Bitsource_forward_iter & operator++() /* prefix */
+        {
             assert(container_ and "Incrementing iterator with no container.");
             assert((end(*container_) != cont_iter_) and "Incrementing past end of container");
-            if (current_mask_ == last_mask_) {
+            if (current_mask_ == last_mask_)
+            {
                 current_mask_ = start_mask_;
                 ++cont_iter_;
-            } else {
+            }
+            else
+            {
                 increment_mask(current_mask_, direction_);
             }
             return *this;
         }
-        bool operator==(Bitsource_forward_iter const &other) const {
-            assert(((container_ == other.container_) or (not container_) or (not other.container_)) and ("Comparing iterators to different containers."));
-            if (not other.container_) {  // Special case for other is end iter. // TODO??: what!?!?!
+        Bitsource_forward_iter & operator++(int) /* postfix */
+        {
+            auto result{*this};
+            ++this;
+            return result;
+        }
+        bool operator==(Bitsource_forward_iter const &other) const
+        {
+            assert(((container_ == other.container_) or (not container_) or (not other.container_))
+                    and ("Comparing iterators to different containers."));
+            if (not other.container_)
+            {
                 return (not container_) or (end(*container_) == cont_iter_);
-            } else {
-                if (not container_) {    // Special case for we are end iter.
+            }
+            else
+            {
+                if (not container_)
+                {
                     return (not other.container_) or (end(*other.container_) == other.cont_iter_);
                 }
             }
             return container_ == other.container_ and cont_iter_ == other.cont_iter_ and current_mask_ == other.current_mask_;
         }
         bool operator!=(Bitsource_forward_iter const &other) const { return !(*this == other); }
+
     private:
         static constexpr uintmax_t         start_mask_  { detail::make_mask(start_bit) };
         static constexpr uintmax_t         last_mask_   { detail::make_mask(last_bit) };
@@ -264,5 +309,6 @@ namespace biterator {
     
     template <auto start_bit = 0, auto last_bit = 7, Integral_container Container = std::string>
     auto end(Container &)    { return Bitsource_forward_iter<start_bit, last_bit, Container>{}; }
+
 } // namespace biterator namespace
 

--- a/iterator_bitset_plus/biterator.hpp
+++ b/iterator_bitset_plus/biterator.hpp
@@ -6,113 +6,263 @@
 #include <cassert>
 #include <iostream>
 
-namespace biterator { // NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-namespace detail {
-enum struct Direction { Up, Down, Neither};
-// A mask is a binary pattern that can be applied to a set of bits to either select or alter specific portions of those bits.
-consteval auto direction(auto start_bit = 0, auto last_bit = 7)
-    requires std::is_same_v<decltype(start_bit),decltype(last_bit)> and
-    std::is_integral_v<decltype(start_bit)> and std::is_integral_v<decltype(last_bit)> {
-    if (last_bit == start_bit) return Direction::Neither;
-    if (last_bit > start_bit) return Direction::Up;
-    return Direction::Down;
-}
-consteval auto make_mask(auto bit_position)
-    requires std::is_integral_v<decltype(bit_position)> {
-    uintmax_t mask_value{ 1 };
-    return mask_value << bit_position;
-}
-constexpr auto increment_mask(uintmax_t &mask, Direction d) {
-    if (d == Direction::Up) { mask <<= 1; } else if (d == Direction::Down) { mask >>= 1; }
-    // Direction::neither is a no-op.
-}
-
-} // END detail Namespace NNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNNN
-
-template <typename Container> concept Integral_container = std::integral<typename Container::value_type>;
-
-/*
-    Bitset_output_iter is an output iterator that writes a bit at time into an std::bitset.
-    Note that it starts with the most significant bit and writes to the least significant bit.
-*/
-template <std::size_t bitset_size>  // value
-struct Bitset_output_iter {
-    using iterator_category = std::output_iterator_tag;
-    using difference_type   = std::ptrdiff_t;
-    using value_type        = bool;
-    Bitset_output_iter(std::bitset<bitset_size> & bs, std::size_t initial_offset = 0) : bs_{ &bs }, offset_{ bitset_size - initial_offset - 1} {}
-    auto operator*() -> Bitset_output_iter & { return *this; }
-    auto operator++()    -> Bitset_output_iter & { --offset_; return *this; }
-    auto operator++(int) -> Bitset_output_iter   { --offset_; return *this; }
-    auto operator=(bool val) -> Bitset_output_iter & {
-        (*bs_)[offset_] = val;
-        return *this;
-    }
-private:
-    std::bitset<bitset_size> *bs_;
-    std::size_t              offset_;
-};
-
-/*
-    Bitsource_forward_iter is an forward iterator that reads bits from a source container of integral values (an Integral_container).
-    The caller specifies a range of bits of each source value.
-*/
-
-template <auto start_bit = 6, auto last_bit = 0, Integral_container Container = std::string>
-    requires std::is_integral_v<decltype(start_bit)> and std::is_integral_v<decltype(last_bit)>
-struct Bitsource_forward_iter {  // forward iterator for reading an Integral_container.
-    using iterator_category = std::forward_iterator_tag;
-    using value_type        = bool;
-    using difference_type   = std::ptrdiff_t;
-    using reference         = bool const &;
-    using pointer           = bool const *;
-    Bitsource_forward_iter(                                                   ): container_{ nullptr }                                      {}
-    Bitsource_forward_iter( Container& container                              ): container_{ &container }, cont_iter_{ begin(*container_) } {}
-    Bitsource_forward_iter( Container& container, Container::const_iterator it): container_{ &container }, cont_iter_{ it}                  {}
-    reference operator*() const {
-        assert(container_ and "Dereferencing iterator with no container.");
-        assert((end(*container_) != cont_iter_) and "Dereferencing past end of container");
-        current_value_ = *cont_iter_ & current_mask_;
-        return current_value_;
-    }
-    pointer operator->() const { return &operator*(); }
-    Bitsource_forward_iter & operator++() {
-        assert(container_ and "Incrementing iterator with no container.");
-        assert((end(*container_) != cont_iter_) and "Incrementing past end of container");
-        if (current_mask_ == last_mask_) {
-            current_mask_ = start_mask_;
-            ++cont_iter_;
-        } else {
-            increment_mask(current_mask_, direction_);
+namespace biterator {
+    namespace detail
+    {
+        enum struct Direction { Up, Down, Neither};
+        consteval auto direction(auto start_bit = 0, auto last_bit = 7)
+            requires std::is_same_v<decltype(start_bit),decltype(last_bit)> and
+            std::is_integral_v<decltype(start_bit)> and std::is_integral_v<decltype(last_bit)>
+        {
+            if (last_bit == start_bit) return Direction::Neither;
+            if (last_bit > start_bit) return Direction::Up;
+            return Direction::Down;
         }
-        return *this;
-    }
-    bool operator==(Bitsource_forward_iter const &other) const {
-        assert(((container_ == other.container_) or (not container_) or (not other.container_)) and ("Comparing iterators to different containers."));
-        if (not other.container_) {  // Special case for other is end iter. // TODO??: what!?!?!
-            return (not container_) or (end(*container_) == cont_iter_);
-        } else {
-            if (not container_) {    // Special case for we are end iter.
-                return (not other.container_) or (end(*other.container_) == other.cont_iter_);
+        consteval auto make_mask(auto bit_position)
+            requires std::is_integral_v<decltype(bit_position)>
+        {
+            uintmax_t mask_value{ 1 };
+            return mask_value << bit_position;
+        }
+        constexpr auto increment_mask(uintmax_t &mask, Direction d)
+        {
+            if (d == Direction::Up) { mask <<= 1; } else if (d == Direction::Down) { mask >>= 1; }
+            // Direction::neither is a no-op.
+        }    
+    } // namespace detail
+
+    template <typename Container> concept Integral_container = std::integral<typename Container::value_type>;
+    
+    /*
+        Bitset_output_iter is an output iterator that writes a bit at time into an std::bitset.
+        Note that it starts with the most significant bit and writes to the least significant bit.
+    */
+    template <std::size_t bitset_size>  // value
+    struct Bitset_output_iter
+    {
+        using iterator_category = std::output_iterator_tag;
+        using difference_type   = std::ptrdiff_t;
+        using value_type        = bool;
+        Bitset_output_iter() = default;
+        Bitset_output_iter(Bitset_output_iter const& orginal) = default;
+        Bitset_output_iter(std::bitset<bitset_size> & bs, std::size_t initial_offset = 0):
+            bs_{ &bs },
+            offset_{bitset_size - initial_offset - 1}
+        {}
+        auto operator*() -> Bitset_output_iter & { return *this; }
+        auto operator++()    /* postfix */ -> Bitset_output_iter & { --offset_; return *this; }
+        auto operator++(int) /* postfix */ -> Bitset_output_iter   { --offset_; return *this; }
+        auto operator==(const Bitset_output_iter& rhs) const { return bs_ == rhs.bs_ and offset_ == rhs.offset_; }
+        auto operator!=(const Bitset_output_iter& rhs) const { return not (*this == rhs); }
+        auto operator=(bool val) -> Bitset_output_iter &
+        {
+            (*bs_)[offset_] = val;
+            return *this;
+        }
+    private:
+        std::bitset<bitset_size> *bs_{nullptr};
+        std::size_t              offset_{0};
+    };
+    
+    /*
+        Bitset_const_forward_iter is an read-only forward iterator that reads a bit at time.
+        Note that it starts with the most significant bit and reads to the least significant bit.
+    */
+    template <std::size_t bitset_size>  // value
+    struct Bitset_const_forward_iter
+    {
+        using iterator_category = std::forward_iterator_tag;
+        using difference_type   = std::ptrdiff_t;
+        using value_type        = bool;
+        Bitset_const_forward_iter() = default;
+        Bitset_const_forward_iter(Bitset_const_forward_iter const& orginal) = default;
+        Bitset_const_forward_iter(std::bitset<bitset_size> & bs, std::size_t initial_offset = 0):
+            bs_{ &bs },
+            offset_{ bitset_size - initial_offset - 1}
+        {}
+        auto operator*() -> Bitset_const_forward_iter & { return (*bs_)[offset_]; }
+        auto operator++()    /* prefix */  -> Bitset_const_forward_iter & { --offset_; return *this; }
+        auto operator++(int) /* postfix */ -> Bitset_const_forward_iter   { --offset_; return *this; }
+        auto operator==(const Bitset_const_forward_iter& rhs) const { return bs_ == rhs.bs_ and offset_ == rhs.offset_; }
+        auto operator!=(const Bitset_const_forward_iter& rhs) const { return not (*this == rhs); }
+        auto operator=(bool val) -> Bitset_const_forward_iter &
+        {
+            (*bs_)[offset_] = val;
+            return *this;
+        }
+    private:
+        std::bitset<bitset_size> *bs_{nullptr};
+        std::size_t              offset_{0};
+    };
+    
+    /*
+        Bitset_iter is an random-access iterator that reads/writes a bit at time.
+        Note that it starts with the most significant bit and reads to the least significant bit.
+    */
+    template <std::size_t bitset_size>  // value
+    struct Bitset_iter
+    {
+        using iterator_category = std::random_access_iterator_tag;
+        using difference_type   = std::ptrdiff_t;
+        using value_type        = bool;
+        struct BitRef
+        {
+            BitRef() {}
+            BitRef(BitRef const&) = default;
+            BitRef(std::bitset<bitset_size> & bs, std::size_t initial_offset = 0):
+                bs_{ &bs },
+                offset_{ bitset_size - initial_offset - 1}
+            {}
+            operator bool() const {return (*bs_)[offset_];}
+            BitRef& operator=(bool v) {(*bs_)[offset_] = v; return *this;}
+            private:
+                std::bitset<bitset_size> *bs_{nullptr};
+                std::size_t              offset_{0};
+        };
+        using reference         = BitRef;
+        using pointer           = bool const *;
+        Bitset_iter() = default;
+        Bitset_iter(Bitset_iter const& orginal) = default;
+        Bitset_iter(std::bitset<bitset_size> & bs, std::size_t initial_offset = 0):
+            bs_{ &bs },
+            offset_{ bitset_size - initial_offset - 1}
+        {}
+        auto operator*() -> BitRef { return BitRef(*bs_, offset_);}
+        auto operator++()    /* prefix */  -> Bitset_iter & { --offset_; return *this; }
+        auto operator++(int) /* postfix */ -> Bitset_iter   { --offset_; return *this; }
+        auto operator==(const Bitset_iter& rhs) const { return bs_ == rhs.bs_ and offset_ == rhs.offset_; }
+        auto operator!=(const Bitset_iter& rhs) const { return not (*this == rhs); }
+        auto operator=(bool val) -> Bitset_iter &
+        {
+            (*bs_)[offset_] = val;
+            return *this;
+        }
+
+        // Comparison functions iterators must reference the same container.
+        friend auto operator<(Bitset_iter const& rhs,  Bitset_iter const& lhs)
+        {
+            assert(((not rhs.bs_) or (not lhs.bs_)) && "Comparing iterator not referencing a container.");
+            assert(rhs.bs_ == lhs.bs_ && "Comparing iterators from different containers.");
+            return rhs.offset > lhs.offset; // Offset progress downward, so > offset reflects a < interator.
+        };
+        friend auto operator>(Bitset_iter const& rhs,  Bitset_iter const& lhs)
+        {
+            assert(((not rhs.bs_) or (not lhs.bs_)) && "Comparing iterator not referencing a container.");
+            assert(rhs.bs_ == lhs.bs_ && "Comparing iterators from different containers.");
+            return rhs.offset < lhs.offset; // Offset progress downward, so < offset reflects a > interator.
+        };
+        friend auto operator<=(Bitset_iter const& rhs,  Bitset_iter const& lhs)
+        {
+            assert(((not rhs.bs_) or (not lhs.bs_)) && "Comparing iterator not referencing a container.");
+            assert(rhs.bs_ == lhs.bs_ && "Comparing iterators from different containers.");
+            return rhs.offset >= lhs.offset; // Offset progress downward, so >= offset reflects a <= interator.
+        };
+        friend auto operator>=(Bitset_iter const& rhs,  Bitset_iter const& lhs)
+        {
+            assert(((not rhs.bs_) or (not lhs.bs_)) && "Comparing iterator not referencing a container.");
+            assert(rhs.bs_ == lhs.bs_ && "Comparing iterators from different containers.");
+            return rhs.offset <= lhs.offset; // Offset progress downward, so <= offset reflects a >= interator.
+        };
+    
+        Bitset_iter& operator+=(int delta)
+        {
+            assert(delta <= offset_ && "Incrementing iterator past end of bitset.");
+            offset_ -= delta; return this;
+        }
+        friend Bitset_iter operator+(Bitset_iter const& lhs, int delta)
+        {
+            assert(delta <= lhs.offset_ && "Incrementing iterator past end of bitset.");
+            return Bitset_iter(lhs.bs_, lhs.offset_ - delta);
+        }
+        friend Bitset_iter operator+(int delta, Bitset_iter const& rhs)
+        {
+            assert(delta <= rhs.offset_ && "Incrementing iterator past end of bitset.");
+            return Bitset_iter(rhs.bs_, rhs.offset_ - delta);
+        }
+        Bitset_iter& operator-=(int delta)
+        {
+            assert(bitset_size - offset_ <= delta && "Decrementing iterator before beginning of bitset.");
+            offset_ += delta; return this;
+        }  
+        friend Bitset_iter operator-(Bitset_iter const& lhs, int delta)
+        {
+            assert(bitset_size - lhs.offset_ <= delta && "Decrementing iterator before beginning of bitset.");
+            return Bitset_iter(lhs.bs_, lhs.offset_ + delta);
+        }  
+        friend difference_type operator-(Bitset_iter const& lhs, Bitset_iter const& rhs)
+        {
+            assert(rhs.bs_ == lhs.bs_ && "Subtracting iterators from different containers.");
+            return difference_type(rhs.offset) - difference_type(lhs.offset_);
+            // Offset progress downward, so Subtrahend - Minuend instead of Minuend - Subtrahend.
+        }  
+    
+        reference operator[](std::size_t) const {current_value_ = (*bs_)[offset_]; return current_value_;}
+    private:
+        std::bitset<bitset_size> *bs_{nullptr};
+        std::size_t              offset_{0};
+        bool                     current_value_{false};
+    };
+    
+    /*
+        Bitsource_forward_iter is an forward iterator that reads bits from a source container of integral values (an Integral_container).
+        The caller specifies a range of bits of each source value.
+    */
+    
+    template <auto start_bit = 6, auto last_bit = 0, Integral_container Container = std::string>
+        requires std::is_integral_v<decltype(start_bit)> and std::is_integral_v<decltype(last_bit)>
+    struct Bitsource_forward_iter {  // forward iterator for reading an Integral_container.
+        using iterator_category = std::forward_iterator_tag;
+        using value_type        = bool;
+        using difference_type   = std::ptrdiff_t;
+        using reference         = bool const &;
+        using pointer           = bool const *;
+        Bitsource_forward_iter(                                                   ): container_{ nullptr }                                      {}
+        Bitsource_forward_iter( Container& container                              ): container_{ &container }, cont_iter_{ begin(*container_) } {}
+        Bitsource_forward_iter( Container& container, Container::const_iterator it): container_{ &container }, cont_iter_{ it}                  {}
+        reference operator*() const {
+            assert(container_ and "Dereferencing iterator with no container.");
+            assert((end(*container_) != cont_iter_) and "Dereferencing past end of container");
+            current_value_ = *cont_iter_ & current_mask_;
+            return current_value_;
+        }
+        pointer operator->() const { return &operator*(); }
+        Bitsource_forward_iter & operator++() {
+            assert(container_ and "Incrementing iterator with no container.");
+            assert((end(*container_) != cont_iter_) and "Incrementing past end of container");
+            if (current_mask_ == last_mask_) {
+                current_mask_ = start_mask_;
+                ++cont_iter_;
+            } else {
+                increment_mask(current_mask_, direction_);
             }
+            return *this;
         }
-        return container_ == other.container_ and cont_iter_ == other.cont_iter_ and current_mask_ == other.current_mask_;
-    }
-    bool operator!=(Bitsource_forward_iter const &other) const { return !(*this == other); }
-private:
-    static constexpr uintmax_t         start_mask_  { detail::make_mask(start_bit) };
-    static constexpr uintmax_t         last_mask_   { detail::make_mask(last_bit) };
-    static constexpr detail::Direction direction_   { detail::direction(start_bit, last_bit) };
-    Container                         *container_;
-    typename Container::const_iterator cont_iter_;
-    uintmax_t                          current_mask_{ start_mask_ };
-    mutable bool                       current_value_{false};
-};
+        bool operator==(Bitsource_forward_iter const &other) const {
+            assert(((container_ == other.container_) or (not container_) or (not other.container_)) and ("Comparing iterators to different containers."));
+            if (not other.container_) {  // Special case for other is end iter. // TODO??: what!?!?!
+                return (not container_) or (end(*container_) == cont_iter_);
+            } else {
+                if (not container_) {    // Special case for we are end iter.
+                    return (not other.container_) or (end(*other.container_) == other.cont_iter_);
+                }
+            }
+            return container_ == other.container_ and cont_iter_ == other.cont_iter_ and current_mask_ == other.current_mask_;
+        }
+        bool operator!=(Bitsource_forward_iter const &other) const { return !(*this == other); }
+    private:
+        static constexpr uintmax_t         start_mask_  { detail::make_mask(start_bit) };
+        static constexpr uintmax_t         last_mask_   { detail::make_mask(last_bit) };
+        static constexpr detail::Direction direction_   { detail::direction(start_bit, last_bit) };
+        Container                         *container_;
+        typename Container::const_iterator cont_iter_;
+        uintmax_t                          current_mask_{ start_mask_ };
+        mutable bool                       current_value_{false};
+    };
+    
+    template <auto start_bit = 0, auto last_bit = 7, Integral_container Container = std::string>
+    auto begin(Container &c) { return Bitsource_forward_iter<start_bit, last_bit, Container>{ c }; }
+    
+    template <auto start_bit = 0, auto last_bit = 7, Integral_container Container = std::string>
+    auto end(Container &)    { return Bitsource_forward_iter<start_bit, last_bit, Container>{}; }
+} // namespace biterator namespace
 
-template <auto start_bit = 0, auto last_bit = 7, Integral_container Container = std::string>
-auto begin(Container &c) { return Bitsource_forward_iter<start_bit, last_bit, Container>{ c }; }
-
-template <auto start_bit = 0, auto last_bit = 7, Integral_container Container = std::string>
-auto end(Container &)    { return Bitsource_forward_iter<start_bit, last_bit, Container>{}; }
-
-} // End biterator namespace NNNNNNNNNNNNNNNNNNNNNNNNNN

--- a/iterator_bitset_plus/main.t.cpp
+++ b/iterator_bitset_plus/main.t.cpp
@@ -11,7 +11,13 @@
 
 
 int main() {
-    std::cout<< "$$ testing biterator::Bitset_output_iter:\n\n";
+    /*
+        These "tests" are simple demonstrations of how to use the library and require visual
+        verification that results are as expected.
+        Real unit test coverage needs to be added.
+    */
+
+    std::cout<< "\n\n$$ testing biterator::bitset_iter:\n\n";
 
     std::vector<bool> binary_source{ true, true, false, false, true, true, false, false, true };  // size = 9
     std::string       string_source{ "testing testing" }; //012345678901234
@@ -20,12 +26,12 @@ int main() {
 
     std::cout << "$$ binary_source:";
     std::copy(begin(binary_source), end(binary_source), std::ostream_iterator<bool>(std::cout));
-    std::copy(begin(binary_source), end(binary_source), biterator::Bitset_iter{ small_sink });
+    std::copy(begin(binary_source), end(binary_source), biterator::bitset_iter{ small_sink });
     std::cout << "\n$$ small_sink   :" << small_sink;
-    std::copy(begin(binary_source) + 3, end(binary_source), biterator::Bitset_iter{ small_sink, 3 });
+    std::copy(begin(binary_source) + 3, end(binary_source), biterator::bitset_iter{ small_sink, 3 });
     std::cout << "\n$$ small_sink   :   " << small_sink.to_string().substr(3) << " (offset of 3)\n\n";
 
-    std::cout << "$$ testing biterator::Bitsource_forward_iter:";
+    std::cout << "$$ testing biterator::Bitsource_forward_iter:\n\n";
 
     std::cout << "$$ string_source:";
     std::for_each(begin(string_source), end(string_source),
@@ -36,12 +42,22 @@ int main() {
                 std::cout << ((mask & c)? "1": "0");
             }
         });
-    std::copy(biterator::begin<6, 0>(string_source), biterator::end<6, 0>(string_source), biterator::Bitset_output_iter{ big_sink });
+    std::copy(biterator::begin<6, 0>(string_source), biterator::end<6, 0>(string_source), biterator::bitset_iter{ big_sink });
     std::cout << "\n$$ big_sink     :" << big_sink;
     auto starting_position{biterator::begin<6, 0>(string_source)};
     std::advance(starting_position, 10);
-    std::copy(starting_position, biterator::end<6, 0>(string_source), biterator::Bitset_output_iter{ big_sink, 10 });
+    std::copy(starting_position, biterator::end<6, 0>(string_source), biterator::bitset_iter{ big_sink, 10 });
     std::cout << "\n$$ big_sink     :          " << big_sink.to_string().substr(10) << " (offset of 10)\n\n";
+
+    std::cout << "$$ testing biterator::Bitout_integral_value:\n\n";
+
+    int32_t int_value{0};
+    for (int i{0}; i < 15; ++i)
+    {
+        std::copy(biterator::bitset_iter{big_sink} + (i * 7), biterator::bitset_iter{big_sink} + ((i + 1) * 7), biterator::begin(int_value));
+        std::cout << int_value << '(' << char(int_value) << ") ";
+        int_value = 0;
+    }
 
     std::cout << "\n###" << std::endl;
 }

--- a/iterator_bitset_plus/main.t.cpp
+++ b/iterator_bitset_plus/main.t.cpp
@@ -20,10 +20,12 @@ int main() {
 
     std::cout << "$$ binary_source:";
     std::copy(begin(binary_source), end(binary_source), std::ostream_iterator<bool>(std::cout));
-    std::copy(begin(binary_source), end(binary_source), biterator::Bitset_output_iter{ small_sink });
+    std::copy(begin(binary_source), end(binary_source), biterator::Bitset_iter{ small_sink });
     std::cout << "\n$$ small_sink   :" << small_sink;
-    std::copy(begin(binary_source) + 3, end(binary_source), biterator::Bitset_output_iter{ small_sink, 3 });
+    std::copy(begin(binary_source) + 3, end(binary_source), biterator::Bitset_iter{ small_sink, 3 });
     std::cout << "\n$$ small_sink   :   " << small_sink.to_string().substr(3) << " (offset of 3)\n\n";
+
+    std::cout << "$$ testing biterator::Bitsource_forward_iter:";
 
     std::cout << "$$ string_source:";
     std::for_each(begin(string_source), end(string_source),
@@ -40,10 +42,6 @@ int main() {
     std::advance(starting_position, 10);
     std::copy(starting_position, biterator::end<6, 0>(string_source), biterator::Bitset_output_iter{ big_sink, 10 });
     std::cout << "\n$$ big_sink     :          " << big_sink.to_string().substr(10) << " (offset of 10)\n\n";
-
-    std::cout << "$$ testing biterator::Bitsource_forward_iter:";
-
-
 
     std::cout << "\n###" << std::endl;
 }


### PR DESCRIPTION
There is a lot of clean up here.

The big change is the addition of Bitout_integral_value. This is class that supports writing bits into a integral value. So, for example, one could copy a range of bits from a bitset into a long int. The test code illustrations how to pull bits from a bitset into an int32_t.